### PR TITLE
Expense Monitor chart changes for last 6 months

### DIFF
--- a/force-app/main/default/classes/ExpenseManagerUtil.cls
+++ b/force-app/main/default/classes/ExpenseManagerUtil.cls
@@ -189,19 +189,20 @@ public with sharing class ExpenseManagerUtil {
         String currentFy = '';
         
         // Construct current fiscal year string in the same format as passed parameter
-        if(currentFyDates[0].month() >= 4) {
-            currentFy = currentFyDates[0].year() + '-' + (currentFyDates[1].year() + 1);
-        } else {
-            currentFy = (currentFyDates[0].year() - 1) + '-' + currentFyDates[1].year();
-        }
-        
+        currentFy = currentFyDates[0].year() + '-' + (currentFyDates[1].year());
         // If the requested fiscal year is the current one, get data for last 6 months from today
         if(fy.equals(currentFy)) {
             Date today = Date.today();
-            Date sixMonthsAgo = today.addMonths(-6);
-            
+            Date todayDate = Date.today();
+            Integer lastDay = Date.daysInMonth(todayDate.year(), todayDate.month());
+            // toDate current date's last day of month
+            Date toDate = Date.newInstance(todayDate.year(), todayDate.month(), lastDay);
+            // From Date 6 months ago
+            Date fromDate = toDate.addMonths(-5);
+            fromDate = Date.newInstance(fromDate.year(), fromDate.month(), 1);
+        
             // Get expense data for last 6 months from today
-            return DataProvider.getExpenseByMonth(sixMonthsAgo, today);
+            return DataProvider.getExpenseByMonth(fromDate, toDate);
         } else {
             // For non-current fiscal years, use the existing logic
             List<Date> fyDates = constructFyDate(fy);

--- a/scripts/apex/hello.apex
+++ b/scripts/apex/hello.apex
@@ -53,8 +53,18 @@ System.debug('recordType Map *** : '+SyncDataController.getRecordTypeMap('Invest
 update syncDataItem;
 System.debug('JSON.serialize(syncDataItem)*** : '+JSON.serialize(syncDataItem.Data__c));
 
-System.debug('2024-2025** : '+JSON.serialize(ExpenseManagerUtil.getExpenseByMonth('2024-2025'));
-System.debug('2025-2026** : '+JSON.serialize(ExpenseManagerUtil.getExpenseByMonth('2025-2026'));
+System.debug('2024-2025** : '+JSON.serialize(ExpenseManagerUtil.getExpenseByMonth('2024-2025')));
+System.debug('2025-2026** : '+JSON.serialize(ExpenseManagerUtil.getExpenseByMonth('2025-2026')));
+
+Date todayDate = Date.today();
+Integer lastDay = Date.daysInMonth(todayDate.year(), todayDate.month());
+Date lastDateOfMonth = Date.newInstance(todayDate.year(), todayDate.month(), lastDay);
+System.debug('lastDateOfMonth*** : '+lastDateOfMonth);
+
+Date endDate = lastDateOfMonth.addMonths(-5);
+endDate = Date.newInstance(endDate.year(), endDate.month(), 1);
+System.debug('endDate*** : '+endDate);
+
 
 delete [select id, name, Bank__c, RecordType.Name, Account_Number__c from Investment__c order by Account_Number__c desc];
 List<Sync_Data_Item__c> syncDs = [select id, name, Completed__c, Level__c,Record_Count__c, Error_Message__c,  Child_Record__c, Data__c, Inserted_Records__c from Sync_Data_Item__c where Sync_Data__c = 'a09Hy00000kkfD5IAI'];


### PR DESCRIPTION
PR Title: Fetch last 6 months’ expenses for current FY

Summary:
- Updated ExpenseManagerUtil.getExpenseByMonth(fy) to:
  - Detect if fy is the current fiscal year
  - When current FY, return expenses for the last 6 months from today
  - Otherwise, retain existing behavior to return expenses for the full FY range

Motivation:
- Aligns monthly expense analysis with a rolling 6-month window for the active fiscal year, improving recency and relevance.

Scope:
- Apex: force-app/main/default/classes/ExpenseManagerUtil.cls
- No schema changes or LWC API changes

Testing:
- Verified current FY path returns data for [today - 6 months, today]
- Verified non-current FY path returns full FY range data

Notes:
- Backward compatible for historical FYs
- No changes to DataProvider contract