### PR TITLE
feat: Convert modal to generic button modal with responsive layout

### DIFF
--- a/force-app/main/default/lwc/modal/modal.css
+++ b/force-app/main/default/lwc/modal/modal.css
@@ -1,4 +1,26 @@
 .slds-modal__content {
-    max-height: 400px;
-    overflow-y: auto;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
+.button-container {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+:global(.stacked-button) {
+  flex: 1;
+}
+
+/* Mobile responsive - stack buttons vertically on small screens */
+@media (max-width: 768px) {
+  .button-container {
+    flex-direction: column;
+  }
+
+  :global(.stacked-button) {
+    width: 100%;
+  }
 }

--- a/force-app/main/default/lwc/modal/modal.html
+++ b/force-app/main/default/lwc/modal/modal.html
@@ -1,33 +1,58 @@
 <template>
-    <template if:true={isOpen}>
-        <section role="dialog" tabindex="-1" class="slds-modal slds-fade-in-open" aria-modal="true">
-            <div class="slds-modal__container">
+  <template if:true={isOpen}>
+    <section
+      role="dialog"
+      tabindex="-1"
+      class="slds-modal slds-fade-in-open"
+      aria-modal="true"
+    >
+      <div class="slds-modal__container">
+        <!-- HEADER -->
+        <header class="slds-modal__header">
+          <button class="slds-button slds-modal__close" onclick={handleClose}>
+            <lightning-icon
+              icon-name="utility:close"
+              alternative-text="Close"
+              size="small"
+            ></lightning-icon>
+          </button>
+          <h2 class="slds-text-heading_medium">{title}</h2>
+        </header>
 
-                <!-- HEADER -->
-                <header class="slds-modal__header">
-                    <button class="slds-button slds-modal__close" onclick={handleClose}>
-                        <lightning-icon icon-name="utility:close" alternative-text="Close" size="small"></lightning-icon>
-                    </button>
-                    <h2 class="slds-text-heading_medium">{title}</h2>
-                </header>
-
-                <!-- BODY -->
-                <div class="slds-modal__content slds-p-around_medium">
-                    <slot></slot>
-                </div>
-
-                <!-- FOOTER -->
-                <footer class="slds-modal__footer">
-                    <template if:true={showCancel}>
-                        <lightning-button variant="neutral" label={cancelLabel} onclick={handleClose}></lightning-button>
-                    </template>
-                    <template if:true={showSubmit}>
-                        <lightning-button variant="brand" label={submitLabel} onclick={handleSubmit}></lightning-button>
-                    </template>
-                </footer>
-
+        <!-- BODY -->
+        <div class="slds-modal__content slds-p-around_medium">
+          <slot></slot>
+          <!-- Render buttons in body if buttons array is provided -->
+          <template if:true={buttons}>
+            <div class="button-container">
+              <template for:each={buttons} for:item="button">
+                <lightning-button
+                  key={button.label}
+                  variant={button.variant}
+                  label={button.label}
+                  data-label={button.label}
+                  onclick={handleButtonClick}
+                  class="stacked-button"
+                >
+                </lightning-button>
+              </template>
             </div>
-        </section>
-        <div class="slds-backdrop slds-backdrop_open" onclick={handleBackdropClick}></div>
-    </template>
+          </template>
+        </div>
+
+        <!-- FOOTER -->
+        <footer class="slds-modal__footer">
+          <lightning-button
+            variant="neutral"
+            label="Close"
+            onclick={handleClose}
+          ></lightning-button>
+        </footer>
+      </div>
+    </section>
+    <div
+      class="slds-backdrop slds-backdrop_open"
+      onclick={handleBackdropClick}
+    ></div>
+  </template>
 </template>

--- a/force-app/main/default/lwc/modal/modal.js
+++ b/force-app/main/default/lwc/modal/modal.js
@@ -1,34 +1,38 @@
-import { LightningElement, api } from 'lwc';
+import { LightningElement, api } from "lwc";
 
 export default class Modal extends LightningElement {
-    @api title = 'Modal Title';
-    @api isOpen = false;
+  @api title = "Modal Title";
+  @api isOpen = false;
+  @api buttons = []; // Array of button objects: { label: 'Button Text', variant: 'brand' }
 
-    //@api showCancel = true;
-    //@api showSubmit = true;
-    @api cancelLabel = 'Cancel';
-    @api submitLabel = 'Submit';
+  // Call this from parent to open modal
+  @api open() {
+    this.isOpen = true;
+  }
 
-    // Call this from parent to open modal
-    @api open() {
-        this.isOpen = true;
-    }
+  // Call this from parent or close internally
+  @api close() {
+    this.isOpen = false;
+  }
 
-    // Call this from parent or close internally
-    @api close() {
-        this.isOpen = false;
-    }
+  handleClose() {
+    this.close();
+    this.dispatchEvent(new CustomEvent("close"));
+  }
 
-    handleClose() {
-        this.close();
-        this.dispatchEvent(new CustomEvent('close'));
-    }
+  handleButtonClick(event) {
+    const buttonLabel = event.currentTarget.dataset.label;
+    this.dispatchEvent(
+      new CustomEvent("buttonclick", {
+        detail: {
+          label: buttonLabel
+        }
+      })
+    );
+    this.close();
+  }
 
-    handleSubmit() {
-        this.dispatchEvent(new CustomEvent('submit'));
-    }
-
-    handleBackdropClick() {
-        this.handleClose();
-    }
+  handleBackdropClick() {
+    this.handleClose();
+  }
 }

--- a/force-app/main/default/lwc/stockInvestmentList/stockInvestmentList.html
+++ b/force-app/main/default/lwc/stockInvestmentList/stockInvestmentList.html
@@ -101,14 +101,17 @@
                     </template>
                   </div>
                 </th>
-                <th scope="col" class="col-actions">
-                  <div class="slds-truncate" title="Actions">Actions</div>
-                </th>
               </tr>
             </thead>
             <tbody class="slds-hint-parent">
               <template for:each={formattedStockData} for:item="stock">
-                <tr key={stock.recordId} class="slds-hint-parent">
+                <tr
+                  key={stock.recordId}
+                  class="slds-hint-parent"
+                  onclick={handleRowClick}
+                  data-id={stock.recordId}
+                  style="cursor: pointer"
+                >
                   <td
                     data-label="Stock Name"
                     class="col-name slds-p-vertical_xx-small word-break"
@@ -143,44 +146,11 @@
                   >
                     <div class={stock.diffClass}>{stock.diffValue}</div>
                   </td>
-                  <td
-                    data-label="Actions"
-                    class="action-cell slds-p-vertical_xx-small"
-                  >
-                    <!-- Single actions menu button -->
-                    <lightning-button-menu
-                      alternative-text="Actions"
-                      icon-name="utility:down"
-                      menu-alignment="auto"
-                      onselect={handleActionsMenuSelect}
-                      data-id={stock.recordId}
-                    >
-                      <span slot="trigger">
-                        <lightning-button
-                          variant="neutral"
-                          label="Actions"
-                          data-id={stock.recordId}
-                        ></lightning-button>
-                      </span>
-                      <lightning-menu-item
-                        value="more"
-                        label="More"
-                      ></lightning-menu-item>
-                      <lightning-menu-item
-                        value="buy"
-                        label="Buy"
-                      ></lightning-menu-item>
-                      <lightning-menu-item
-                        value="sell"
-                        label="Sell"
-                      ></lightning-menu-item>
-                    </lightning-button-menu>
-                  </td>
                 </tr>
                 <!-- Expanded details row - only rendered when expanded -->
                 <template if:true={stock.isExpanded}>
                   <tr key={stock.expandedRowKey} data-stock-id={stock.recordId}>
-                    <td colspan="5" class="slds-p-vertical_xx-small">
+                    <td colspan="4" class="slds-p-vertical_xx-small">
                       <div class="text-align-left">
                         <template if:true={stock.lines}>
                           <div class="slds-p-around_x-small">
@@ -235,4 +205,13 @@
       </div>
     </div>
   </template>
+
+  <!-- Button Modal -->
+  <c-modal
+    title="Stock Actions"
+    is-open={showButtonModal}
+    buttons={modalButtons}
+    onbuttonclick={handleModalButtonClick}
+  >
+  </c-modal>
 </template>

--- a/force-app/main/default/lwc/stockInvestmentList/stockInvestmentList.js
+++ b/force-app/main/default/lwc/stockInvestmentList/stockInvestmentList.js
@@ -1,293 +1,358 @@
-import { LightningElement, wire, api, track } from 'lwc';
-import {log, logError, isValidValue, toString, formatDate} from 'c/utilityClass';
-import getAllStock from '@salesforce/apex/ExpenseManagerUtil.getAllStocks';
-import refreshStockPrice from '@salesforce/apex/ExpenseManagerUtil.refreshStockPrice';
-import buySellStock from 'c/buySellStockModal';
-import { refreshApex } from '@salesforce/apex';
-
+import { LightningElement, wire, api, track } from "lwc";
+import {
+  log,
+  logError,
+  isValidValue,
+  toString,
+  formatDate
+} from "c/utilityClass";
+import getAllStock from "@salesforce/apex/ExpenseManagerUtil.getAllStocks";
+import refreshStockPrice from "@salesforce/apex/ExpenseManagerUtil.refreshStockPrice";
+import buySellStock from "c/buySellStockModal";
+import { refreshApex } from "@salesforce/apex";
 export default class StockInvestmentList extends LightningElement {
-    @track stockData;
-    stockProvisionedData;
-    expandedStockIds = new Set(); // Track which stock IDs are expanded
-    @track last10Transaction = [];
-    isOpen = false;
-    totalInvested = 0;
-    totalCurrentValue = 0;
-    totalDiff = 0;
-    headerNote = '';
-    @track originalData;
-    @track diffSortOrder = null; // null (original), 'desc' (greater to smaller), 'asc' (smaller to greater)
-    totalDiffClass = 'header-diff-positive';
+  @track stockData;
+  stockProvisionedData;
+  expandedStockIds = new Set(); // Track which stock IDs are expanded
+  @track last10Transaction = [];
+  isOpen = false;
+  totalInvested = 0;
+  totalCurrentValue = 0;
+  totalDiff = 0;
+  headerNote = "";
+  @track originalData;
+  @track diffSortOrder = null; // null (original), 'desc' (greater to smaller), 'asc' (smaller to greater)
+  totalDiffClass = "header-diff-positive";
+  @track showButtonModal = false;
+  @track selectedStockId = null;
+  @track modalButtons = [
+    { label: "More", variant: "neutral" },
+    { label: "Buy", variant: "brand" },
+    { label: "Sell", variant: "brand" }
+  ];
 
-    get searchClass() {
-        return this.isOpen ? 'search-box open' : 'search-box';
+  get searchClass() {
+    return this.isOpen ? "search-box open" : "search-box";
+  }
+
+  toggleSearch() {
+    this.isOpen = !this.isOpen;
+  }
+
+  handleSearch(event) {
+    let searchString = event.target.value.toLowerCase();
+    if (!searchString) {
+      this.stockData = this.originalData;
+      return;
     }
+    this.stockData = this.originalData.filter((item) =>
+      item.stockName.toLowerCase().includes(searchString)
+    );
+  }
 
-    toggleSearch() {
-        this.isOpen = !this.isOpen;
+  handleReset() {
+    this.stockData = this.originalData;
+  }
+
+  handleRefresh() {
+    refreshStockPrice()
+      .then((result) => {
+        log("Stock prices refreshed successfully: " + result);
+        refreshApex(this.stockProvisionedData);
+      })
+      .catch((error) => {
+        logError("Error refreshing stock prices: " + toString(error));
+      });
+  }
+
+  getHeaderNote() {
+    if (this.last10Transaction.length < 1) {
+      return "";
     }
+    let message = "*Last share ";
+    message += "(" + this.stockData[0].stockName + ") ";
+    message += this.last10Transaction[0].buySell == "Buy" ? "bought " : "sold ";
+    message += "on " + formatDate(new Date(this.last10Transaction[0].sdate));
+    return message;
+  }
 
-    handleSearch(event) {
-        let searchString = event.target.value.toLowerCase();
-        if(!searchString) {
-            this.stockData = this.originalData;
-            return;
-        }
-        this.stockData = this.originalData.filter(item =>
-            item.stockName.toLowerCase().includes(searchString)
-        );
-    
-    }
-
-    handleReset() {
-        this.stockData = this.originalData;
-    }
-
-    handleRefresh() {
-        refreshStockPrice().then(result => {
-            log('Stock prices refreshed successfully: '+result);
-            refreshApex(this.stockProvisionedData);
-        }).catch(error => {
-            logError('Error refreshing stock prices: '+toString(error));
+  @wire(getAllStock, {})
+  fetchStocks(stockObjs) {
+    this.stockProvisionedData = stockObjs;
+    if (stockObjs.data) {
+      let stocks = JSON.parse(JSON.stringify(stockObjs.data));
+      this.totalInvested = 0;
+      this.totalCurrentValue = 0;
+      stocks.forEach((stock) => {
+        this.totalInvested += Number(stock.totalInvested) || 0;
+        this.totalCurrentValue += Number(stock.currentValue) || 0;
+        stock.quantity = Number(stock.quantity);
+        stock.totalSold = Number(stock.totalSold);
+        stock.lines.forEach((stockLine) => {
+          stockLine.styleclass =
+            "slds-grid slds-gutters slds-var-p-vertical_xx-small";
+          if (stockLine.buySell == "Sell") {
+            stockLine.styleclass += " sold-hilighter";
+          }
+          if (this.last10Transaction.length < 10) {
+            this.last10Transaction.push(stockLine);
+          }
+          stockLine.sdate = formatDate(new Date(stockLine.sdate));
         });
+      });
+      this.totalDiff = this.totalInvested - this.totalCurrentValue;
+      this.totalDiffClass =
+        this.totalCurrentValue < this.totalInvested
+          ? "header-diff-negative"
+          : "header-diff-positive";
+      //this.stockData = stockObjs.data;
+      this.stockData = stocks;
+      this.headerNote = this.getHeaderNote();
+      this.originalData = stocks;
+      log("stock data fetched successfully.... : " + toString(this.stockData));
+    }
+  }
+
+  // Toggle the expanded state for a stock
+  toggleStockExpansion(stockId) {
+    const expandedStockIds = new Set(this.expandedStockIds);
+    if (expandedStockIds.has(stockId)) {
+      expandedStockIds.delete(stockId);
+    } else {
+      expandedStockIds.add(stockId);
+    }
+    this.expandedStockIds = expandedStockIds;
+  }
+
+  // Handle diff column header click for sorting
+  handleDiffSort() {
+    if (this.diffSortOrder === null) {
+      // First click: sort descending (greater to smaller)
+      this.diffSortOrder = "desc";
+    } else if (this.diffSortOrder === "desc") {
+      // Second click: sort ascending (smaller to greater)
+      this.diffSortOrder = "asc";
+    } else {
+      // Third click: back to original order
+      this.diffSortOrder = null;
+    }
+  }
+
+  // Get icon name based on sort order
+  get diffSortIconName() {
+    return this.diffSortOrder === "desc"
+      ? "utility:arrowdown"
+      : "utility:arrowup";
+  }
+
+  // Getter for formatted stock data with expanded state and sorting
+  get formattedStockData() {
+    if (!this.stockData) return [];
+
+    let dataToFormat = [...this.stockData];
+
+    // Apply diff sorting if active
+    if (this.diffSortOrder) {
+      dataToFormat.sort((a, b) => {
+        const diffA =
+          (Number(a.currentValue) || 0) - (Number(a.totalInvested) || 0);
+        const diffB =
+          (Number(b.currentValue) || 0) - (Number(b.totalInvested) || 0);
+        return this.diffSortOrder === "desc" ? diffB - diffA : diffA - diffB;
+      });
     }
 
-    getHeaderNote() {
-        if(this.last10Transaction.length < 1) {
-            return '';
-        }
-        let message = '*Last share ';
-        message += '('+ this.stockData[0].stockName +') ';
-        message += this.last10Transaction[0].buySell == 'Buy' ? 'bought ' : 'sold ';
-        message += 'on ' + formatDate(new Date(this.last10Transaction[0].sdate));
-        return message;
-    }
+    return dataToFormat.map((stock) => {
+      // Create a copy of the stock object
+      // Determine if return is positive or negative
+      const investedAmount = Number(stock.totalInvested) || 0;
+      const currentValueAmount = Number(stock.currentValue) || 0;
+      const returnStatus =
+        currentValueAmount >= investedAmount ? "positive" : "negative";
 
-    @wire (getAllStock, {})
-    fetchStocks(stockObjs) {
-        this.stockProvisionedData = stockObjs;
-        if(stockObjs.data) {
-            let stocks = JSON.parse(JSON.stringify(stockObjs.data));
-            this.totalInvested = 0;
-            this.totalCurrentValue = 0;
-            stocks.forEach(stock => {
-                this.totalInvested += Number(stock.totalInvested) || 0;
-                this.totalCurrentValue += Number(stock.currentValue) || 0;
-                stock.quantity = Number(stock.quantity);
-                stock.totalSold = Number(stock.totalSold);
-                stock.lines.forEach(
-                    stockLine => {
-                        stockLine.styleclass = 'slds-grid slds-gutters slds-var-p-vertical_xx-small';
-                        if(stockLine.buySell == 'Sell') {
-                            stockLine.styleclass += ' sold-hilighter';
-                        }
-                        if(this.last10Transaction.length < 10) {
-                            this.last10Transaction.push(stockLine);
-                        }
-                        stockLine.sdate = formatDate(new Date(stockLine.sdate));
-                    }
-                );
-            });
-            this.totalDiff = this.totalInvested - this.totalCurrentValue;
-            this.totalDiffClass = this.totalCurrentValue < this.totalInvested ? 'header-diff-negative' : 'header-diff-positive';
-            //this.stockData = stockObjs.data;
-            this.stockData = stocks;
-            this.headerNote = this.getHeaderNote();
-            this.originalData = stocks;
-            log('stock data fetched successfully.... : '+toString(this.stockData));
-        }
-    }
+      // Calculate diff value and class
+      const diff = currentValueAmount - investedAmount;
+      const diffSign = diff < 0 ? "- ₹ " : "₹ ";
+      const diffValue = diffSign + this.formatAmount(Math.abs(diff));
+      const diffClass = diff >= 0 ? "diff-positive" : "diff-negative";
 
-    // Toggle the expanded state for a stock
-    toggleStockExpansion(stockId) {
-        const expandedStockIds = new Set(this.expandedStockIds);
-        if (expandedStockIds.has(stockId)) {
-            expandedStockIds.delete(stockId);
-        } else {
-            expandedStockIds.add(stockId);
-        }
-        this.expandedStockIds = expandedStockIds;
-    }
+      const formattedStock = {
+        ...stock,
+        totalBuyed: this.formatAmount(stock.totalBuyed),
+        totalSold: this.formatAmount(stock.totalSold),
+        totalInvested: this.formatAmount(stock.totalInvested),
+        // Add expanded state property
+        isExpanded: this.expandedStockIds.has(stock.recordId),
+        expandedRowKey: stock.recordId + "_expanded",
+        returnStatus: returnStatus,
+        returnClass:
+          returnStatus === "positive"
+            ? "return-cell positive"
+            : "return-cell negative",
+        diffValue: diffValue,
+        diffClass: diffClass
+      };
 
-    // Handle diff column header click for sorting
-    handleDiffSort() {
-        if (this.diffSortOrder === null) {
-            // First click: sort descending (greater to smaller)
-            this.diffSortOrder = 'desc';
-        } else if (this.diffSortOrder === 'desc') {
-            // Second click: sort ascending (smaller to greater)
-            this.diffSortOrder = 'asc';
-        } else {
-            // Third click: back to original order
-            this.diffSortOrder = null;
-        }
-    }
+      // Format the lines if they exist
+      if (formattedStock.lines && Array.isArray(formattedStock.lines)) {
+        formattedStock.lines = formattedStock.lines.map((line) => ({
+          ...line,
+          amount: this.formatAmount(line.amount)
+        }));
+      }
 
-    // Get icon name based on sort order
-    get diffSortIconName() {
-        return this.diffSortOrder === 'desc' ? 'utility:arrowdown' : 'utility:arrowup';
-    }
+      return formattedStock;
+    });
+  }
 
-    // Getter for formatted stock data with expanded state and sorting
-    get formattedStockData() {
-        if (!this.stockData) return [];
-        
-        let dataToFormat = [...this.stockData];
-        
-        // Apply diff sorting if active
-        if (this.diffSortOrder) {
-            dataToFormat.sort((a, b) => {
-                const diffA = (Number(a.currentValue) || 0) - (Number(a.totalInvested) || 0);
-                const diffB = (Number(b.currentValue) || 0) - (Number(b.totalInvested) || 0);
-                return this.diffSortOrder === 'desc' ? diffB - diffA : diffA - diffB;
-            });
-        }
-        
-        return dataToFormat.map(stock => {
-            // Create a copy of the stock object
-            // Determine if return is positive or negative
-            const investedAmount = Number(stock.totalInvested) || 0;
-            const currentValueAmount = Number(stock.currentValue) || 0;
-            const returnStatus = currentValueAmount >= investedAmount ? 'positive' : 'negative';
-            
-            // Calculate diff value and class
-            const diff = currentValueAmount - investedAmount;
-            const diffSign = diff < 0 ? '- ₹ ' : '₹ ';
-            const diffValue = diffSign + this.formatAmount(Math.abs(diff));
-            const diffClass = diff >= 0 ? 'diff-positive' : 'diff-negative';
-            
-            const formattedStock = {
-                ...stock,
-                totalBuyed: this.formatAmount(stock.totalBuyed),
-                totalSold: this.formatAmount(stock.totalSold),
-                totalInvested: this.formatAmount(stock.totalInvested),
-                // Add expanded state property
-                isExpanded: this.expandedStockIds.has(stock.recordId),
-                expandedRowKey: stock.recordId + '_expanded',
-                returnStatus: returnStatus,
-                returnClass: returnStatus === 'positive' ? 'return-cell positive' : 'return-cell negative',
-                diffValue: diffValue,
-                diffClass: diffClass
-            };
-            
-            // Format the lines if they exist
-            if (formattedStock.lines && Array.isArray(formattedStock.lines)) {
-                formattedStock.lines = formattedStock.lines.map(line => ({
-                    ...line,
-                    amount: this.formatAmount(line.amount)
-                }));
-            }
-            
-            return formattedStock;
+  // Format amount to integer (remove decimals)
+  formatAmount(amount) {
+    if (amount === null || amount === undefined) {
+      return "0";
+    }
+    // Convert to number and round to integer
+    return Math.round(Number(amount)).toLocaleString();
+  }
+
+  // Handle row click to open modal
+  handleRowClick(event) {
+    const stockId = event.currentTarget.dataset.id;
+    this.selectedStockId = stockId;
+    this.showButtonModal = true;
+  }
+
+  // Handle modal button click
+  handleModalButtonClick(event) {
+    const buttonLabel = event.detail.label;
+    this.showButtonModal = false;
+
+    if (buttonLabel === "More") {
+      this.toggleStockExpansion(this.selectedStockId);
+      // Wait for re-render and then scroll
+      window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+          setTimeout(() => this.scrollToExpandedRow(this.selectedStockId), 50);
         });
+      });
+    } else if (buttonLabel === "Buy") {
+      this.buyOrder({
+        currentTarget: { dataset: { id: this.selectedStockId } }
+      });
+    } else if (buttonLabel === "Sell") {
+      this.sellOrder({
+        currentTarget: { dataset: { id: this.selectedStockId } }
+      });
+    }
+  }
+
+  // Single Actions menu handler (More, Buy, Sell)
+  async handleActionsMenuSelect(event) {
+    // Get the ID from the event target's closest data-id attribute
+    let id = "";
+    // Check if the event detail has the ID directly
+    if (event.detail && event.detail.id) {
+      id = event.detail.id;
+    }
+    // If not, try to find the data-id from the event target or currentTarget
+    else if (event.currentTarget && event.currentTarget.dataset) {
+      id = event.currentTarget.dataset.id;
+    } else if (event.target && event.target.closest) {
+      const closestWithDataId = event.target.closest("[data-id]");
+      if (closestWithDataId) {
+        id = closestWithDataId.dataset.id;
+      }
+    }
+    // If still no ID, try to get it from the menu trigger
+    else if (
+      event.target &&
+      event.target.parentElement &&
+      event.target.parentElement.dataset
+    ) {
+      id = event.target.parentElement.dataset.id;
+    }
+    // Final fallback - try to get from event.detail if it contains the id
+    else if (event.detail && event.detail.id) {
+      id = event.detail.id;
     }
 
-    // Format amount to integer (remove decimals)
-    formatAmount(amount) {
-        if (amount === null || amount === undefined) {
-            return '0';
-        }
-        // Convert to number and round to integer
-        return Math.round(Number(amount)).toLocaleString();
-    }
+    const action = event.detail.value;
+    if (action === "more") {
+      // Scroll only when opening (before toggle, row is not expanded yet)
+      const isOpening = !this.expandedStockIds.has(id);
+      this.toggleStockExpansion(id);
 
-    // Single Actions menu handler (More, Buy, Sell)
-    async handleActionsMenuSelect(event) {
-        // Get the ID from the event target's closest data-id attribute
-        let id = '';
-        // Check if the event detail has the ID directly
-        if (event.detail && event.detail.id) {
-            id = event.detail.id;
-        }
-        // If not, try to find the data-id from the event target or currentTarget
-        else if (event.currentTarget && event.currentTarget.dataset) {
-            id = event.currentTarget.dataset.id;
-        }
-        else if (event.target && event.target.closest) {
-            const closestWithDataId = event.target.closest('[data-id]');
-            if (closestWithDataId) {
-                id = closestWithDataId.dataset.id;
-            }
-        }
-        // If still no ID, try to get it from the menu trigger
-        else if (event.target && event.target.parentElement && event.target.parentElement.dataset) {
-            id = event.target.parentElement.dataset.id;
-        }
-        // Final fallback - try to get from event.detail if it contains the id
-        else if (event.detail && event.detail.id) {
-            id = event.detail.id;
-        }
-        
-        const action = event.detail.value;
-        if (action === 'more') {
-            // Scroll only when opening (before toggle, row is not expanded yet)
-            const isOpening = !this.expandedStockIds.has(id);
-            this.toggleStockExpansion(id);
-
-            if (isOpening) {
-                // Wait for LWC to re-render the expanded row before scrolling (double rAF + short delay)
-                window.requestAnimationFrame(() => {
-                    window.requestAnimationFrame(() => {
-                        setTimeout(() => this.scrollToExpandedRow(id), 50);
-                    });
-                });
-            }
-        } else if (action === 'buy') {
-            await this.buyOrder({ currentTarget: { dataset: { id: id } } });
-        } else if (action === 'sell') {
-            await this.sellOrder({ currentTarget: { dataset: { id: id } } });
-        }
-    }
-
-    scrollToExpandedRow(stockId) {
-        const container = this.template.querySelector('.slds-scrollable_y');
-        const expandedRow = this.template.querySelector(`tr[data-stock-id="${stockId}"]`);
-        if (!expandedRow || !container) return;
-
-        // Position relative to scroll container (offsetTop can be relative to table, so use rects)
-        const containerRect = container.getBoundingClientRect();
-        const rowRect = expandedRow.getBoundingClientRect();
-        const headerHeight = this.template.querySelector('.custom-investments-table thead')?.offsetHeight ?? 0;
-        const padding = 8;
-
-        // How far the row's top is from the visible top of the container
-        const rowOffsetFromVisibleTop = rowRect.top - containerRect.top;
-        // Desired scroll: bring row just below the sticky header
-        const targetScrollTop = container.scrollTop + rowOffsetFromVisibleTop - headerHeight - padding;
-        const maxScroll = Math.max(0, container.scrollHeight - container.clientHeight);
-        const clampedScroll = Math.max(0, Math.min(targetScrollTop, maxScroll));
-
-        container.scrollTo({
-            top: clampedScroll,
-            behavior: 'smooth'
+      if (isOpening) {
+        // Wait for LWC to re-render the expanded row before scrolling (double rAF + short delay)
+        window.requestAnimationFrame(() => {
+          window.requestAnimationFrame(() => {
+            setTimeout(() => this.scrollToExpandedRow(id), 50);
+          });
         });
+      }
+    } else if (action === "buy") {
+      await this.buyOrder({ currentTarget: { dataset: { id: id } } });
+    } else if (action === "sell") {
+      await this.sellOrder({ currentTarget: { dataset: { id: id } } });
     }
+  }
 
-    async buyOrder(event) {
-        // Open Buy modal
-        const id = event.currentTarget.dataset.id || event.currentTarget.id;
-        log('inside buy Order.... : ' + id);
-        const result = await buySellStock.open({
-            size: 'small',
-            description: 'Buy/Sell',
-            content: { id: id, actionLabel: 'Buy' },
-        });
-        if (result === 'CREATED') {
-            refreshApex(this.stockProvisionedData);
-        }
-    }
+  scrollToExpandedRow(stockId) {
+    const container = this.template.querySelector(".slds-scrollable_y");
+    const expandedRow = this.template.querySelector(
+      `tr[data-stock-id="${stockId}"]`
+    );
+    if (!expandedRow || !container) return;
 
-    async sellOrder(event) {
-        // Open Sell modal
-        const id = event.currentTarget.dataset.id || event.currentTarget.id;
-        log('inside sell order.... : ' + id);
-        const result = await buySellStock.open({
-            size: 'small',
-            description: 'Buy/Sell',
-            content: { id: id, actionLabel: 'Sell' },
-        });
-        if (result === 'CREATED') {
-            refreshApex(this.stockProvisionedData);
-        }
+    // Position relative to scroll container (offsetTop can be relative to table, so use rects)
+    const containerRect = container.getBoundingClientRect();
+    const rowRect = expandedRow.getBoundingClientRect();
+    const headerHeight =
+      this.template.querySelector(".custom-investments-table thead")
+        ?.offsetHeight ?? 0;
+    const padding = 8;
+
+    // How far the row's top is from the visible top of the container
+    const rowOffsetFromVisibleTop = rowRect.top - containerRect.top;
+    // Desired scroll: bring row just below the sticky header
+    const targetScrollTop =
+      container.scrollTop + rowOffsetFromVisibleTop - headerHeight - padding;
+    const maxScroll = Math.max(
+      0,
+      container.scrollHeight - container.clientHeight
+    );
+    const clampedScroll = Math.max(0, Math.min(targetScrollTop, maxScroll));
+
+    container.scrollTo({
+      top: clampedScroll,
+      behavior: "smooth"
+    });
+  }
+
+  async buyOrder(event) {
+    // Open Buy modal
+    const id = event.currentTarget.dataset.id || event.currentTarget.id;
+    log("inside buy Order.... : " + id);
+    const result = await buySellStock.open({
+      size: "small",
+      description: "Buy/Sell",
+      content: { id: id, actionLabel: "Buy" }
+    });
+    if (result === "CREATED") {
+      refreshApex(this.stockProvisionedData);
     }
+  }
+
+  async sellOrder(event) {
+    // Open Sell modal
+    const id = event.currentTarget.dataset.id || event.currentTarget.id;
+    log("inside sell order.... : " + id);
+    const result = await buySellStock.open({
+      size: "small",
+      description: "Buy/Sell",
+      content: { id: id, actionLabel: "Sell" }
+    });
+    if (result === "CREATED") {
+      refreshApex(this.stockProvisionedData);
+    }
+  }
 }


### PR DESCRIPTION
## Description
Convert the modal component to a generic reusable modal that accepts dynamic buttons and displays them in a responsive layout.

## Changes
- **Modal Component**: Updated to accept a `buttons` array with dynamic button configurations
- **Button Layout**: Renders buttons in modal body (not footer) with responsive design
  - Desktop: Single row (3 buttons side by side)
  - Mobile: Stacked vertically (3 rows)
- **Stock Investment List**: Integrated with new modal
  - Removed Actions column from table
  - Made stock rows clickable to open the button modal
  - Button clicks (More, Buy, Sell) execute respective actions
- **Footer**: Simplified to show only Close button (X button remains in header)

## Files Modified
- `force-app/main/default/lwc/modal/modal.js` - Updated to handle dynamic buttons
- `force-app/main/default/lwc/modal/modal.html` - Restructured layout with buttons in body
- `force-app/main/default/lwc/modal/modal.css` - Added responsive styling with media queries
- `force-app/main/default/lwc/stockInvestmentList/stockInvestmentList.js` - Integrated modal functionality
- `force-app/main/default/lwc/stockInvestmentList/stockInvestmentList.html` - Removed Actions column, added clickable rows

## Testing
- Verify modal displays correctly on desktop with buttons in single row
- Verify modal displays correctly on mobile with buttons stacked
- Test stock row click opens modal with correct buttons
- Test each button (More, Buy, Sell) performs expected action